### PR TITLE
Fixed bug with disappearing on bounce cell (second from the last one in collection)

### DIFF
--- a/Pod/Classes/PopupCollectonViewController.swift
+++ b/Pod/Classes/PopupCollectonViewController.swift
@@ -142,7 +142,7 @@ open class PopupCollectionViewController: UIViewController {
         self.popupCollectionView.reloadData()
     }
 
-    func didTapGesture(_ sender: UITapGestureRecognizer) {
+    @objc func didTapGesture(_ sender: UITapGestureRecognizer) {
         self.dismiss(completion: nil)
     }
 }
@@ -362,6 +362,14 @@ extension PopupCollectionViewController: UICollectionViewDataSource {
     public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         let vc = self.childViewControllers[indexPath.item]
         vc.view.removeFromSuperview()
+    }
+    
+    public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        let vc = self.childViewControllers[indexPath.row]
+        if vc.view.superview != cell {
+            vc.view.frame = cell.bounds
+            cell.addSubview(vc.view)
+        }
     }
 }
 


### PR DESCRIPTION
In current state viewController's view is being removed in `didEndDisplaying` and added only `cellForItemAt`. For the cell next to last ones (or to be more correct ones on the edge of the collection: first and last one) on bounce `didEndDisplaying` happened, so view was removed, but cell had no need be created, so cell ended up without view in it.

This fix just add view of viewController on `willDisplay`, iff it's not already subview of the cell. So even cell loses subview on `didEndDisplaying` during bounce, it gets it back before displaying.

Also, `@objc` added to `didTapGesture` because `#selector()` was demanding it.